### PR TITLE
`is-equal-shallow` fails for comparisons of (A, B) A ⊃ B

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,15 @@ module.exports = function isEqual(a, b) {
   if (!a && !b) { return true; }
   if (!a && b || a && !b) { return false; }
 
-  for (var key in b) {
+  var numKeysA = 0, numKeysB = 0, key;
+  for (key in b) {
+    numKeysB++;
     if (!isPrimitive(b[key]) || !a.hasOwnProperty(key) || (a[key] !== b[key])) {
       return false;
     }
   }
-  return true;
+  for (key in a) {
+    numKeysA++;
+  }
+  return numKeysA === numKeysB;
 };

--- a/test.js
+++ b/test.js
@@ -29,4 +29,9 @@ describe('equals', function () {
     equals({ b: {}}, { b: {}}).should.be.false;
     equals({ b: []}, { b: []}).should.be.false;
   });
+
+  it('should return false when a value is present in one object but not the other', function () {
+    equals({a: true, b: true, c: true}, {a: true, b: true}).should.be.false;
+    equals({a: true, b: true}, {a: true, b: true, c: true}).should.be.false;
+  });
 });


### PR DESCRIPTION
When trying to use `regex-cache@0.4.2` with `micromatch`, 10 of the tests in `micromatch` fail because when their `opts` are checked for equality, `is-equal-shallow` wrongly returns true.

This is because the opts in these tests are a proper subset of the cached opts.
